### PR TITLE
Update to v6.12.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sip" %}
-{% set version = "6.10.0" %}
+{% set version = "6.12.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sip-{{ version }}.tar.gz
-  sha256: fa0515697d4c98dbe04d9e898d816de1427e5b9ae5d0e152169109fd21f5d29c
+  sha256: 083ced94f85315493231119a63970b2ba42b1d38b38e730a70e02a99191a89c6
 
 build:
   number: 0
@@ -25,17 +25,17 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
   host:
     - python
     - pip
-    - setuptools
-    - setuptools_scm
-    - wheel
+    - setuptools >=77
+    - setuptools_scm >=8
   run:
     - python
-    - packaging
-    - setuptools >=69.5
+    - packaging >=24.2
+    - setuptools >=75.8.1
     - tomli  # [py<311]
 
 test:
@@ -52,6 +52,16 @@ test:
     - sipbuild.tools
   files:
     - test
+  commands:
+    - pip check
+    # make sure the version reported by pip is correct
+    - "pip show {{ name }} | grep -Fx 'Version: {{ version }}'"  # [not win]
+    - sip-distinfo --help
+    - sip-module --help
+    - sip-build --help
+    - sip-install --help
+    - sip-sdist --help
+    - sip-wheel --help
 
 about:
   home: https://pypi.org/project/sip/
@@ -70,6 +80,7 @@ about:
 extra:
   skip-lints:
     - python_build_tool_in_run
+    - has_run_test_and_commands
   recipe-maintainers:
     - andfoy
     - ccordoba12

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,18 +1,3 @@
-pip check
-if errorlevel 1 exit 1
-sip-distinfo --help
-if errorlevel 1 exit 1
-sip-module --help
-if errorlevel 1 exit 1
-sip-build --help
-if errorlevel 1 exit 1
-sip-install --help
-if errorlevel 1 exit 1
-sip-sdist --help
-if errorlevel 1 exit 1
-sip-wheel --help
-if errorlevel 1 exit 1
-
 cd test
 sip-build
 if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -2,13 +2,5 @@
 
 set -exou
 
-pip check
-sip-distinfo --help
-sip-module --help
-sip-build --help
-sip-install --help
-sip-sdist --help
-sip-wheel --help
-
 cd test
 sip-build


### PR DESCRIPTION
sip 6.12.0

**Destination channel:** defaults

### Links

- [PKG-8700](https://anaconda.atlassian.net/browse/PKG-8700)
- [Upstream repository](https://github.com/Python-SIP/sip/tree/6.12.0)
- [Upstream changelog/diff](https://github.com/Python-SIP/sip/compare/6.10.0...6.12.0)

### Explanation of changes:

- Moved tests into recipe to simplify


[PKG-8700]: https://anaconda.atlassian.net/browse/PKG-8700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ